### PR TITLE
Don't upload pipeline if no steps added

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -61,6 +61,11 @@ func uploadPipeline(plugin Plugin, generatePipeline PipelineGenerator) (string, 
 		return "", []string{}, err
 	}
 
+	if len(steps) < 1 {
+		log.Info("No steps to trigger. Skipping pipeline upload.")
+		return "", []string{}, nil
+	}
+
 	pipeline, err := generatePipeline(steps, plugin)
 	defer os.Remove(pipeline.Name())
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -17,7 +17,7 @@ func mockGeneratePipeline(steps []Step, plugin Plugin) (*os.File, error) {
 }
 
 func TestUploadPipelineCallsBuildkiteAgentCommand(t *testing.T) {
-	plugin := Plugin{Diff: "echo ./foo-service", Interpolation: true}
+	plugin := Plugin{Diff: "echo 123", Interpolation: true, Watch: []WatchConfig{{Paths: []string{"123"}, Step: Step{}}}}
 	cmd, args, err := uploadPipeline(plugin, mockGeneratePipeline)
 
 	assert.Equal(t, "buildkite-agent", cmd)
@@ -26,7 +26,7 @@ func TestUploadPipelineCallsBuildkiteAgentCommand(t *testing.T) {
 }
 
 func TestUploadPipelineCallsBuildkiteAgentCommandWithInterpolation(t *testing.T) {
-	plugin := Plugin{Diff: "echo ./foo-service", Interpolation: false}
+	plugin := Plugin{Diff: "echo 123", Interpolation: false, Watch: []WatchConfig{{Paths: []string{"123"}, Step: Step{}}}}
 	cmd, args, err := uploadPipeline(plugin, mockGeneratePipeline)
 
 	assert.Equal(t, "buildkite-agent", cmd)
@@ -36,6 +36,15 @@ func TestUploadPipelineCallsBuildkiteAgentCommandWithInterpolation(t *testing.T)
 
 func TestUploadPipelineCancelsIfThereIsNoDiffOutput(t *testing.T) {
 	plugin := Plugin{Diff: "echo"}
+	cmd, args, err := uploadPipeline(plugin, mockGeneratePipeline)
+
+	assert.Equal(t, "", cmd)
+	assert.Equal(t, []string{}, args)
+	assert.Equal(t, err, nil)
+}
+
+func TestUploadPipelineCancelsIfThereIsNoSteps(t *testing.T) {
+	plugin := Plugin{Diff: "echo 123"}
 	cmd, args, err := uploadPipeline(plugin, mockGeneratePipeline)
 
 	assert.Equal(t, "", cmd)


### PR DESCRIPTION
Buildkite agent will fail if pipeline has empty steps

As seen here: 
```
INFO[0000] --- running monorepo-diff-buildkite-plugin 0.0.1
INFO[2024-11-23T12:26:38Z] Running diff command: .buildkite/scripts/git-diff.sh
Generated Pipeline:
steps:
- group: Monorepo CI
  steps: []
FATA[2024-11-23T12:26:39Z] +++ failed to upload pipeline: command `buildkite-agent` failed: exit status 1
```

Empty steps should be a valid state